### PR TITLE
Package-extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "watch": "node esbuild.js --watch",
     "package": "node esbuild.js --production",
     "compile-tests": "tsc -p . --outDir out",
-    "pretest": "npm run compile-tests && npm run lint",
+    "pretest": "npm run lint",
     "test": "vscode-test",
     "lint": "eslint ."
   },


### PR DESCRIPTION
The test files are already JavaScript (.js) and don't need TypeScript compilation.
This fixes the PR validation workflow failure.